### PR TITLE
feat: 설정 값 불러오기 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    compileOnly 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
 dependencyManagement {

--- a/src/main/java/com/example/cloudtest/CloudTestApplication.java
+++ b/src/main/java/com/example/cloudtest/CloudTestApplication.java
@@ -1,10 +1,8 @@
 package com.example.cloudtest;
 
-import jakarta.annotation.PostConstruct;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -15,8 +13,6 @@ import org.springframework.stereotype.Component;
 
 @SpringBootApplication
 public class CloudTestApplication {
-
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   public static void main(String[] args) {
     SpringApplication.run(CloudTestApplication.class, args);
@@ -29,19 +25,20 @@ public class CloudTestApplication {
 
     private final Environment environment;
 
-    @Value("${host.api.venom}")
-    private String venom;
+    @Value("${spring.config.import}")
+    private List<String> imports;
 
+    @Value("${szs.sdk.venom.api.host}")
+    private String venom;
+//
     @Value("${szs.sdk.venom.api.key}")
     private String key;
 
     @Override
     public void run(ApplicationArguments args) {
-      log.info("print config start");
-      log.info("{}", environment);
-      log.info("{}", venom);
-      log.info("{}", key);
-      log.info("print config end");
+      System.out.println(venom);
+      System.out.println(key);
+      imports.forEach(System.out::println);
     }
   }
 }

--- a/src/main/java/com/example/cloudtest/CloudTestApplication.java
+++ b/src/main/java/com/example/cloudtest/CloudTestApplication.java
@@ -1,32 +1,47 @@
 package com.example.cloudtest;
 
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
 
 @SpringBootApplication
 public class CloudTestApplication {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  @Value("${redis-url}")
-  private String redisUrl;
-
-  @Value("${database-url}")
-  private String databaseUrl;
   public static void main(String[] args) {
     SpringApplication.run(CloudTestApplication.class, args);
   }
 
+  @Component
+  @Slf4j
+  @RequiredArgsConstructor
+  static class TestRunner implements ApplicationRunner {
 
-  @PostConstruct
-  void setUp () {
+    private final Environment environment;
 
-    logger.info("redis url : " + redisUrl);
-    logger.info("database url : " + databaseUrl);
+    @Value("${host.api.venom}")
+    private String venom;
 
+    @Value("${szs.sdk.venom.api.key}")
+    private String key;
+
+    @Override
+    public void run(ApplicationArguments args) {
+      log.info("print config start");
+      log.info("{}", environment);
+      log.info("{}", venom);
+      log.info("{}", key);
+      log.info("print config end");
+    }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,10 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-#      profile: dev
+      label: master
+      enabled: true
+  #      profile: ${spring.profiles.active}, host, db # default {spring.profiles.active}
   config:
     import: 'optional:configserver:'
   profiles:
-    active: dev
+    active: dev, venom

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,11 @@
-
-
 spring:
   application:
-    name: szs-platform-api
+    name: cloud-test
   cloud:
     config:
       uri: http://localhost:8888
-      profile: dev,cache-redis
-
+#      profile: dev
   config:
-    import: 'configserver:'
-
-redis-url: 'local-redis'
-database-url : 'local-db'
-server:
-  port: 9090
+    import: 'optional:configserver:'
+  profiles:
+    active: dev


### PR DESCRIPTION
search-paths 테스트 해봤어요.

제가 동작 방식을 잘못 이해해서 클라이언트가 동적으로 서버에서 검색할 곳을 찾아줄 수 있을 거 같았는데 그건 아닌 거 같네요 ㅜㅜ

서버 쪽에 push 하긴했는데

```
search-paths:
  - '{application}/{profile}'
  - 'infra/host/{profile}'
  - 'infra/*/*/{profile}'
```

이런식으로 호스트 정보를 다른 설정에 주입할 수 있게 읽어와야 할 거 같아요.
다른 설정은 정리해서 다 넣어놓고 키 매핑해서 쓰거나 properties로 매핑해서 쓰도록 가이드해야할듯 😢 

장점
- host 정보 직접 입력할 필요 없음
- sdk 정보 등도 직접 입력할 필요 없음

단점
- 주입하는 곳에서 결국 키를 제대로 알고 있어야하는데 본인 설정이 아닌 모여있는 곳에서 설정을 찾아야 함
- api key 같은 경우 결국 따로 관리해야하는데 이 때 키가 뭔지 또 찾아봐야 함

(쓰는 김에 여기다 씀)
제가 생각한 이상적인 방향

config - application - profile 내 yml

```
szs:
  import:
    sdk:
      - venom:
          key: 1234
          # 그 외 커스터마이징 할 항목
      - terry:
          key: abcd
          # 그 외 커스터마이징 할 항목
    datasource:
      - szs
    other:
      - foo:
         # 커스터마이징 항목
```

혹시 가능할지도 모른다고 생각하는 방법

```
spring:
  config:
    import: 
      - 'optional:flie/infra/db/venom'  # 절대경로, 상대경로로 모두 해보았으나 실패
      - 'optional:file/infra/sdk/venom'
```

```
spring:
  application:
    name: cloud-test
  cloud:
    config:
      uri: http://localhost:8888
      profile: ${spring.profiles.active}, host, db # default {spring.profiles.active}
  config:
    import: 'optional:configserver:'
  profiles:
    active: dev
```